### PR TITLE
feature/referrals

### DIFF
--- a/src/routes/api/twilio/incoming/+server.js
+++ b/src/routes/api/twilio/incoming/+server.js
@@ -35,8 +35,8 @@ export async function POST({ request }) {
 			user = await User.create({ phone: from, notificationConsent: false });
 		}
 
-		const isStopRequest = body === 'STOP';
-		const isStartRequest = body === 'START';
+		const isStopRequest = body.toLowerCase() === 'stop';
+		const isStartRequest = body.toLowerCase() === 'start';
 		let adminMessage = `${user ? user.username : from} sent a message. https://scones.ike.coffee/account/admin?user=${user.id}`;
 
 		// disable textConsent if message contains 'STOP'
@@ -48,11 +48,12 @@ export async function POST({ request }) {
 			await user.save();
 
 			await createAndSendMessage({
-				body: 'You have unsubscribed from sconifications. TYSM for enforcing your digital boundaries <3. You can start recieving notifications again by texting START to this number.',
-				to: user.phone
+				body: '${user.username} have unsubscribed from sconifications.',
+				to: ADMIN_NUMBER
 			});
 		}
 
+		// enable text consent if message contains 'START'
 		if (isStartRequest) {
 			// reset admin message:
 			adminMessage = `${user.username || user.phone} has started text notifications! https://scones.ike.coffee/account/admin?user=${user.id}`;
@@ -61,8 +62,8 @@ export async function POST({ request }) {
 			await user.save();
 
 			await createAndSendMessage({
-				body: 'You have subscribed from sconifications!',
-				to: user.phone
+				body: '${user.username} has subscribed to sconifications!',
+				to: ADMIN_NUMBER
 			});
 		}
 


### PR DESCRIPTION
- **MessageLog component, composer, and twilio endpoint for getting messages**
- **complete messagecomposer component**
- **completed messagelog component**
- **added send and read message component and refresh icon**
- **moved formatPhoneNumber to utils folder so it can be shared**
- **moved formatPhoneNumber to utils folder so it can be shared**
- **added a link to message center that only admin can see**
- **added redirect whenever the admin is not logged in**
- **replaced MessageComposer and MessageLog components with a single MessagingComponent**
- **created dedicated endpoint for reading sms from a single user**
- **created an endpoint for getting all consenting phone numbers in database (only admins can use it)**
- **added code that pings admin when a message is stored in the database**
- **added a global page-container class**
- **bug, typo**
- **bug, forgot to add imports and init for twilio**
- **bug, forgot to add imports and init for twilio**
- **added STOP option for textConsent, and some admin messages to let admin know when stop happens**
- **moved user=null to before goto call so that code reaches it**
- **created a utility function that both adds message to database and sends it from TWILIO_NUMBER**
- **removed the direction field in message documents since it can be infered from other fields**
- **added referral field, and added a check to make sure password is initialized before validating it**
- **added a user specific referral link to account dashboard**
- **added a function for creating a referral link from user id**
- **create a custom component for sending hardcoded messages to all users**
- **fixed some formatting issues, usable but not great looking**
- **moved formatPhone number to shared client/server utils file**
- **added getReferralLinkFromId function**
- **added SenAllMessageComposer to bottom of page**
- **incoming messages now accept START and STOP commands from users**
- **added a hardcoded messaging route for sending unique messages**
- **creating an account now automatically sends an onboarding message to the number associated with it**
- **fixed some password check bugs**
- **user now gets removed from locals whenever they are logged out**
- **signup page now either shows a referral signup (no password needed to create account) or a regular account creator with password**
- **fix: typing bug for number**
- **added missing imports to messages**
- **added missing if statement**
- **adjusted formatting of phone number to not care about + symbol**
- **fix: checks for password being defined before testing if the passwords match**
- **added company name to onboard message**
- **referrals from ike don't navigate away from signup page**
- **edited formatter to work with Number typed phone fields**
- **adding referral link to onboard message**
- **adding referral link to onboard message**
- **fixed send-referral-link frontend error**
- **fixed bug with processing stop and start requests**
